### PR TITLE
Add configuration file and keep launcher setting persisted

### DIFF
--- a/src/IntelOrca.OpenLauncher.Core/ConfigService.cs
+++ b/src/IntelOrca.OpenLauncher.Core/ConfigService.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace IntelOrca.OpenLauncher.Core
+{
+    public class ConfigService
+    {
+        private static string ConfigFileDir => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenLauncher");
+        private static string ConfigFilePath => Path.Combine(ConfigFileDir, "config.json");
+
+        private static readonly JsonSerializerOptions _serializerOptions = new ()
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        private Config _config = new();
+
+
+        public ConfigService()
+        {
+            if (!File.Exists(ConfigFilePath))
+            {
+                SaveConfig();
+            }
+            else
+            {
+                var configJson = File.ReadAllText(ConfigFilePath);
+                _config = JsonSerializer.Deserialize<Config>(configJson, _serializerOptions);
+            }
+        }
+
+        private void SaveConfig()
+        {
+            var configJson = JsonSerializer.Serialize(_config, _serializerOptions);
+            Directory.CreateDirectory(ConfigFileDir);
+            File.WriteAllText(ConfigFilePath, configJson);
+        }
+
+        public bool PreReleaseChecked
+        {
+            get => _config.PreReleaseChecked;
+            set
+            {
+                _config.PreReleaseChecked = value;
+                SaveConfig();
+            }
+        }
+
+        public int SelectingGame
+        {
+            get => _config.SelectingGame;
+            set
+            {
+                _config.SelectingGame = value;
+                SaveConfig();
+            }
+        }
+    }
+
+
+    internal struct Config
+    {
+        public Config()
+        {
+        }
+        
+        public bool PreReleaseChecked { get; set; } = false;
+        public int SelectingGame { get; set; } = 0;
+    }
+}

--- a/src/IntelOrca.OpenLauncher.Core/ConfigService.cs
+++ b/src/IntelOrca.OpenLauncher.Core/ConfigService.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace IntelOrca.OpenLauncher.Core
 {
@@ -11,14 +9,13 @@ namespace IntelOrca.OpenLauncher.Core
         private static string ConfigFileDir => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenLauncher");
         private static string ConfigFilePath => Path.Combine(ConfigFileDir, "config.json");
 
-        private static readonly JsonSerializerOptions _serializerOptions = new ()
+        private static readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions()
         {
             WriteIndented = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
 
-        private Config _config = new();
-
+        private Config _config;
 
         public ConfigService()
         {
@@ -28,16 +25,28 @@ namespace IntelOrca.OpenLauncher.Core
             }
             else
             {
-                var configJson = File.ReadAllText(ConfigFilePath);
-                _config = JsonSerializer.Deserialize<Config>(configJson, _serializerOptions);
+                try
+                {
+                    var configJson = File.ReadAllText(ConfigFilePath);
+                    _config = JsonSerializer.Deserialize<Config>(configJson, _serializerOptions);
+                }
+                catch
+                {
+                }
             }
         }
 
         private void SaveConfig()
         {
-            var configJson = JsonSerializer.Serialize(_config, _serializerOptions);
-            Directory.CreateDirectory(ConfigFileDir);
-            File.WriteAllText(ConfigFilePath, configJson);
+            try
+            {
+                var configJson = JsonSerializer.Serialize(_config, _serializerOptions);
+                Directory.CreateDirectory(ConfigFileDir);
+                File.WriteAllText(ConfigFilePath, configJson);
+            }
+            catch
+            {
+            }
         }
 
         public bool PreReleaseChecked
@@ -61,14 +70,9 @@ namespace IntelOrca.OpenLauncher.Core
         }
     }
 
-
     internal struct Config
     {
-        public Config()
-        {
-        }
-        
-        public bool PreReleaseChecked { get; set; } = false;
-        public int SelectingGame { get; set; } = 0;
+        public bool PreReleaseChecked { get; set; }
+        public int SelectingGame { get; set; }
     }
 }

--- a/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
+++ b/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 </Project>

--- a/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
+++ b/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
+++ b/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
@@ -6,6 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.6" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/openlauncher/MainWindow.axaml.cs
+++ b/src/openlauncher/MainWindow.axaml.cs
@@ -16,6 +16,7 @@ namespace openlauncher
     public partial class MainWindow : Window
     {
         private readonly BuildService _buildService = new();
+        private readonly ConfigService _configService = new();
 
         private GameMenuItem? _selectedMenuItem;
         private bool _ready;
@@ -41,7 +42,8 @@ namespace openlauncher
 
         private async void Window_Opened(object sender, EventArgs e)
         {
-            gameListView.SelectedIndex = 0;
+            showPreReleaseCheckbox.IsChecked = _configService.PreReleaseChecked;
+            gameListView.SelectedIndex = _configService.SelectingGame;
             _ready = true;
             var selectedItem = gameListView.SelectedItem as GameMenuItem;
             await SetPageAsync(selectedItem);
@@ -54,9 +56,6 @@ namespace openlauncher
 
         private async Task SetPageAsync(GameMenuItem? item)
         {
-            if (!_ready)
-                return;
-
             _selectedMenuItem = item;
             if (item != null)
             {
@@ -89,11 +88,17 @@ namespace openlauncher
 
         private async void gameListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (!_ready)
+                return;
+            _configService.SelectingGame = gameListView.SelectedIndex;
             await SetPageAsync(gameListView.SelectedItem as GameMenuItem);
         }
 
         private async void showPreReleaseCheckbox_Changed(object sender, RoutedEventArgs e)
         {
+            if (!_ready)
+                return;
+            _configService.PreReleaseChecked = showPreReleaseCheckbox.IsChecked ?? false;
             await RefreshAvailableVersionsAsync();
         }
 


### PR DESCRIPTION
This is pretty basic but actual data persistence on Avalonia required ReactiveUI which this repo doesn't have, also it would be really overkill.

Newer .net has System.Text.Json built-in so I have to update target framework and save config in json format.

Fix: #4 


