### PR TITLE
Update to .NET 8.0 and refactor tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Restore
       run: dotnet restore
     - name: Build
@@ -30,14 +30,14 @@ jobs:
       working-directory: src/openlauncher
       run: dotnet publish -c Release -r ${{ matrix.rid }} --self-contained
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: "OpenLauncher-${{ matrix.rid }}"
-        path: src/openlauncher/bin/Release/net7.0/${{ matrix.rid }}/publish/**/*
+        path: src/openlauncher/bin/Release/net8.0/${{ matrix.rid }}/publish/**/*
     - name: Create release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         files: |
-          src/openlauncher/bin/Release/net7.0/${{ matrix.rid }}/publish/openlauncher
-          src/openlauncher/bin/Release/net7.0/${{ matrix.rid }}/publish/openlauncher.exe
+          src/openlauncher/bin/Release/net8.0/${{ matrix.rid }}/publish/openlauncher
+          src/openlauncher/bin/Release/net8.0/${{ matrix.rid }}/publish/openlauncher.exe

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/openlauncher/bin/Debug/net7.0/openlauncher.dll",
+            "program": "${workspaceFolder}/src/openlauncher/bin/Debug/net8.0/openlauncher.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A launcher for automatically downloading the latest, or specific versions of [Op
 
 # 🔨 Building
 
-**Open Launcher** is written in C# using the [AvaloniaUI](http://avaloniaui.net) framework. The application currently targets [.NET 6](https://dotnet.microsoft.com) and is typically distributed as a self contained executable.
+**Open Launcher** is written in C# using the [AvaloniaUI](http://avaloniaui.net) framework. The application currently targets [.NET 8](https://dotnet.microsoft.com) and is typically distributed as a self contained executable.
 
 ### Prerequisites
-* [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+* [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 * [Visual Studio](https://visualstudio.microsoft.com) (optional)
   * [AvaloniaUI extension](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaVS) (optional)
 * [Visual Studio Code](https://code.visualstudio.com) (optional)

--- a/src/IntelOrca.OpenLauncher.Core/Build.cs
+++ b/src/IntelOrca.OpenLauncher.Core/Build.cs
@@ -33,16 +33,20 @@ namespace IntelOrca.OpenLauncher.Core
 
         public override string ToString() => Version;
 
-        public int CompareTo(Build other)
+        public int CompareTo(Build? other)
         {
+            ArgumentNullException.ThrowIfNull(other);
+
             var a = PublishedAt;
             var b = other.PublishedAt;
+
             if (a is null && b is null)
                 return 0;
             if (a is null)
                 return 1;
             if (b is null)
                 return -1;
+
             return b.Value.CompareTo(a.Value);
         }
     }

--- a/src/IntelOrca.OpenLauncher.Core/BuildAsset.cs
+++ b/src/IntelOrca.OpenLauncher.Core/BuildAsset.cs
@@ -117,8 +117,13 @@ namespace IntelOrca.OpenLauncher.Core
 
         public static BuildAssetComparer Default = new BuildAssetComparer();
 
-        public int Compare(BuildAsset x, BuildAsset y)
+        public int Compare(BuildAsset? x, BuildAsset? y)
         {
+            if (x == null || y == null)
+            {
+                throw new ArgumentNullException("BuildAsset objects cannot be null");
+            }
+
             if (x.Platform == y.Platform)
             {
                 if (x.Arch != y.Arch)

--- a/src/IntelOrca.OpenLauncher.Core/InstallService.cs
+++ b/src/IntelOrca.OpenLauncher.Core/InstallService.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 
 namespace IntelOrca.OpenLauncher.Core
 {
@@ -73,12 +74,15 @@ namespace IntelOrca.OpenLauncher.Core
                 {
                     RedirectStandardError = true
                 };
-                var process = Process.Start(psi);
+
+                var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start process '{psi}'");
+
                 var outputBuilder = new StringBuilder();
                 var sw = Stopwatch.StartNew();
+
                 while (sw.ElapsedMilliseconds < 2000)
                 {
-                    var s = process.StandardError.ReadToEnd();
+                    string? s = process.StandardError.ReadToEnd();
                     if (s != null)
                         outputBuilder.Append(s);
 

--- a/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
+++ b/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
@@ -5,7 +5,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
+++ b/src/IntelOrca.OpenLauncher.Core/IntelOrca.OpenLauncher.Core.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/src/IntelOrca.OpenLauncher.Core/Shell.cs
+++ b/src/IntelOrca.OpenLauncher.Core/Shell.cs
@@ -25,7 +25,7 @@ namespace IntelOrca.OpenLauncher.Core
             {
                 psi.ArgumentList.Add(arg);
             }
-            var p = Process.Start(psi);
+            var p = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start process '{name}'");
             p.WaitForExit();
             return p.ExitCode;
         }

--- a/src/openlauncher/openlauncher.csproj
+++ b/src/openlauncher/openlauncher.csproj
@@ -19,6 +19,9 @@
     <ApplicationIcon>resources\logo.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+</ItemGroup>
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/openlauncher/openlauncher.csproj
+++ b/src/openlauncher/openlauncher.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
@@ -42,10 +42,10 @@
     <ProjectReference Include="..\IntelOrca.OpenLauncher.Core\IntelOrca.OpenLauncher.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia" Version="0.10.22" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.22" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.22" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
   </ItemGroup>
   <ItemGroup>

--- a/test/IntelOrca.OpenLauncher.Tests/IntelOrca.OpenLauncher.Tests.csproj
+++ b/test/IntelOrca.OpenLauncher.Tests/IntelOrca.OpenLauncher.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updated target frameworks to .NET 8.0 in `launch.json`, `IntelOrca.OpenLauncher.Core.csproj`, `openlauncher.csproj`, and `IntelOrca.OpenLauncher.Tests.csproj`. v6 will be deprecated soon. v7 is already deprecated since May 14, 2024

 Upgraded various NuGet packages to their latest Minor versions. to not introduced regression i've upgraded only dotnet 8 files and few minor hotfix versions
 
 Refactored `BuildServiceTests.cs` to use `[Theory]` with `InlineData` and introduced a helper method for asset matching. -> to fix tests on local machine